### PR TITLE
Deploy Lambda to AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Example usage:
 6. Run for the first time:
 ```
 >> virtualenv .env
->> pip install -r requirements.txt
 >> . .env/bin/activate
+>> pip install -r requirements.txt
 >> python save_all
 ```
 
@@ -46,4 +46,10 @@ get all events -> save in firebase --> upload to S3 ->
                         ^                            |
                         <- get most recent events <-<-
 ```
+
+### Deploy to AWS Lambda
+1. Create a new Role for lambda full access, and past the role arn in `lambda.json`
+2. run `./deploy.sh`
+
+
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+touch google/__init__.py
+
+lambda-uploader --virtualenv=.env
+

--- a/firebase.py
+++ b/firebase.py
@@ -21,11 +21,17 @@ class Firebase():
 
     def _firebase_login(self, creds_path, database_url):
         cred = credentials.Certificate(creds_path)
-        #  Initialize the app with a service account, granting admin privileges
-        firebase_admin.initialize_app(cred, {
-            'databaseURL': database_url,
-        })
-        root = db.reference()
+        #  Initialize a single app with a service account, granting admin privileges
+        try:
+            firebase_admin.initialize_app(cred, {
+                'databaseURL': database_url,
+            })
+            root = db.reference()
+        except ValueError as e:
+            if 'app already exists' in e.message:
+                root = db.reference()
+            else:
+                raise e
 
         return root
 

--- a/lambda.json
+++ b/lambda.json
@@ -1,0 +1,19 @@
+{
+  "name": "groupMeSyncFunction",
+  "description": "Keep GroupMe and S3 in sync",
+  "region": "us-west-2",
+  "runtime": "python2.7",
+  "handler": "lambda_func.handler",
+  "role": "arn:aws:iam::210751417156:role/lambda_full_access",
+  "requirements": ["pygithub"],
+  "ignore": [
+    "circle\\.yml$",
+    "\\.git$",
+    "/.*\\.pyc$"
+  ],
+  "timeout": 300,
+  "memory": 512,
+  "tracing": {
+    "Mode": "Active"
+  }
+}

--- a/lambda_func.py
+++ b/lambda_func.py
@@ -1,0 +1,17 @@
+import config
+from queue_up import save_since_last_message, backup_media_to_s3
+from groupme import GroupMeAPI
+from firebase import Firebase
+
+
+def handler(event, context):
+    '''Save all messages since last, and backup all media to S3
+    '''
+    groupme_api = GroupMeAPI(config.GROUPME_URL, config.GROUP_ID, config.GROUP_NAME, config.GROUPME_ACCESS_TOKEN)
+    firebase_db = Firebase(config.FIREBASE_SERVICE_ACCOUNT_PRIVATE_KEY, config.FIREBASE_DATABASE_URL)
+
+    save_since_last_message(groupme_api, firebase_db)
+    backup_media_to_s3(firebase_db)
+
+    print('done')
+    return True

--- a/queue_up.py
+++ b/queue_up.py
@@ -108,12 +108,12 @@ def backup_media_to_s3(firebase_db):
         media_type = event['type']
 
         try:
-            filename = file_utils.download_file_from_url(src_url, media_type, event_id)
+            filename, filepath = file_utils.download_file_from_url(src_url, media_type, event_id)
 
-            s3_utils.upload(filename)
+            s3_utils.upload(filepath, key=filename)
 
             # delete local file
-            file_utils.delete_file(filename)
+            file_utils.delete_file(filepath)
 
             # update firebase with 'backup_link'
             event['backup_link'] = filename
@@ -141,5 +141,5 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # TODO: upgrade to python 3.6
-    # TODO: push to aws scheduled function
+    # TODO: schedule lamba function
     main(args.action)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ arrow==0.10.0
 boto3==1.4.6
 firebase-admin==2.1.1
 requests==2.18.3
+lambda-uploader==1.2.0

--- a/s3_utils.py
+++ b/s3_utils.py
@@ -15,13 +15,14 @@ stdoutput.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s
 logger.addHandler(stdoutput)
 
 
-def upload(filename):
+def upload(filepath, key):
     s3 = boto3.resource('s3')
 
-    logger.info('uploading {} to S3'.format(filename))
+    logger.info('uploading {} to S3, located at {}'.format(key, filepath))
     total_time = arrow.now()
-    with open(filename, 'rb') as rb:
-        s3.Bucket(config.S3_BUCKET).put_object(Key=filename, Body=rb, Tagging='groupme=true')
+
+    with open(filepath, 'rb') as rb:
+        s3.Bucket(config.S3_BUCKET).put_object(Key=key, Body=rb, Tagging='groupme=true')
 
     total_time = arrow.now() - total_time
-    logger.info('finished uploading {} to S3. took {} seconds'.format(filename, total_time))
+    logger.info('finished uploading {} to S3. took {} seconds'.format(key, total_time))


### PR DESCRIPTION
Use lambda-uploader to deploy the newly created `lambda_func.py` to AWS.
AWS Lambda functions can only write to the `/tmp` directory. Store downloaded files in `/tmp`.
Also, only 1 instance of a firebase app can be running at a time. So fixed the Firebase constructor to return the app, if one already exists.

- store files in `/tmp` and upload from there as well
- created deploy.sh to deploy to S3. It creates an `__init__.py` file in the `google` folder so that the deploy works.